### PR TITLE
Rate Limit Feature to waste attacker time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,17 @@ LABEL maintainer="Justin Azoff <justin.azoff@gmail.com>" \
 ENV USER=nobody
 ENV SSHD_BIND=:2222
 
-RUN go install github.com/JustinAzoff/ssh-auth-logger@latest && \
+WORKDIR /app
+
+COPY . .
+
+RUN go install . && \
     touch /var/log/ssh-auth-logger.log && \
-    chown nobody /var/log/ssh-auth-logger.log && \ 
+    chown $USER /var/log/ssh-auth-logger.log && \
     chmod 644 /var/log/ssh-auth-logger.log
 
 USER $USER
 
 EXPOSE 2222
 
-CMD /go/bin/ssh-auth-logger 2>&1 | tee -a /var/log/ssh-auth-logger.log
+CMD test -f /var/log/ssh-auth-logger.log || { echo 'Creating log file...' && touch /var/log/ssh-auth-logger.log ; }; /go/bin/ssh-auth-logger 2>&1 | tee -a /var/log/ssh-auth-logger.log

--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ services:
     image: justinazoff/ssh-auth-logger:latest
     container_name: ssh-auth-logger
     environment:
-      # Port to listen
-      - SSHD_BIND=:2222
+      - SSHD_RATE=120    # bits per second, emulate very slow connection
+      - SSHD_BIND=:2222  # Port and interface to listen
+      - TZ=Europe/Berlin # You can set Time Zone to see logs with your local time
     volumes:
       # Mount log file if needed
-      - /var/docker/ssh-auth-logger/ssh-auth.log:/var/log/ssh-auth-logger.log
+      - /var/docker/ssh-auth-logger/log:/var/log
     ports:
      - 2222:2222 # SSH Auth Logger
     restart: unless-stopped
@@ -81,7 +82,7 @@ services:
           cpus: '0.50'
           memory: 100M
     healthcheck:
-      test: wget -v localhost:$SSHD_BIND --no-verbose --tries=1 --spider || exit 1
+      test: wget -v localhost$SSHD_BIND --no-verbose --tries=1 --spider || exit 1
       interval: 5m00s
       timeout: 5s
       retries: 2


### PR DESCRIPTION
- Add Rate Limit Feature, default rate is `120` bytes per second. Controlled via `SSHD_RATE` Variable and emulates slow connection.
- Add Starting message output to logs with current Variables set.
```json
{"SSHD_BIND":":2222","SSHD_KEY_KEY":"Take me to your leader","SSHD_RATE":5000,"level":"info","msg":"Starting SSH Auth Logger","time":"2025-10-08T17:06:15+02:00"}
```
- `Dockerfile` update - install from the local folder (project).
- Add test to check if log file was not created in case of folder mount and create it.
- Minor `README.md` update, somehow file mount was not working well.
- Add Time Zone control via `TZ` Variable.