### PR TITLE
Bug with `SSHD_PROFILE_SCOPE`

### DIFF
--- a/main.go
+++ b/main.go
@@ -247,7 +247,11 @@ func makeSSHConfig(conn net.Conn) ssh.ServerConfig {
 	// Determine the key for profile lookup
 	var profileKey string
 	if profileScope == "remote_ip" {
-		profileKey = conn.RemoteAddr().String()
+		host, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+		if err != nil {
+			host = conn.RemoteAddr().String() // fallback, should not happen
+		}
+		profileKey = host
 	} else { // default "host"
 		profileKey = getHost(conn.LocalAddr().String())
 	}


### PR DESCRIPTION
### Bug

When `SSHD_PROFILE_SCOPE` is set to `remote_ip` profiles are evaluated based on remote IP **and** Source Port. This will drive to different Profiles for different connections, but same IP. This commit force evaluation based on IP only.

I think that was you are talking about. Sorry, didn't notice it first.