### PR TITLE
Feature - logging filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ services:
 #      - SSHD_PROFILE_SCOPE=host               # Can be 'remote_ip' (each remote IP gets its own profile, simulating per-attacker behavior.), or anything else for 'host' (the same local host always gets the same profile, e.g. binding to 0.0.0.0:22 will always select the same Profile).
 #      - SSHD_SEND_BANNER=false                # Send SSH Login Banner before Password prompt
 #      - SSHD_LOG_CLEAR_PASSWORD=true          # Log Passwords as clear text or Base64 coded
-#      - SSHD_LOGS_FILTER=duser,src,password   # Comma-separated list of allowed fields. 'msg', 'level' and 'time' can't be removed. Following combinations are possible: duser,src,spt,dst,dpt,client_version,server_version,password,keytype,fingerprint,server_key_type,destinationServicename,product
+#      - SSHD_LOGS_FILTER=""                   # Comma-separated list of allowed fields. 'msg', 'level' and 'time' can't be removed. Following combinations are possible: "duser,src,spt,dst,dpt,client_version,server_version,password,keytype,fingerprint,server_key_type,destinationServicename,product"
       - TZ=Europe/Berlin                      # You can set Time Zone to see logs with your local time
     volumes:
       # Mount log file if needed

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ services:
 #      - SSHD_PROFILE_SCOPE=host               # Can be 'remote_ip' (each remote IP gets its own profile, simulating per-attacker behavior.), or anything else for 'host' (the same local host always gets the same profile, e.g. binding to 0.0.0.0:22 will always select the same Profile).
 #      - SSHD_SEND_BANNER=false                # Send SSH Login Banner before Password prompt
 #      - SSHD_LOG_CLEAR_PASSWORD=true          # Log Passwords as clear text or Base64 coded
-#      - SSHD_LOGS_FILTER=duser,src,password   # Comma-separated list of allowed fields. 'msg', 'level' and 'time' can't be removed. Following combinations are possible: duser,src,spt,dst,dpt,client_version,server_version,password,keytype,fingerprint,server_key_type,destinationServicename,product,<ALL SSHD_* VARIABLES>
+#      - SSHD_LOGS_FILTER=duser,src,password   # Comma-separated list of allowed fields. 'msg', 'level' and 'time' can't be removed. Following combinations are possible: duser,src,spt,dst,dpt,client_version,server_version,password,keytype,fingerprint,server_key_type,destinationServicename,product
       - TZ=Europe/Berlin                      # You can set Time Zone to see logs with your local time
     volumes:
       # Mount log file if needed

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ services:
 #      - SSHD_MAX_AUTH_TRIES=6                 # The minimum number of authentication attempts allowed
 #      - SSHD_RSA_BITS=3072                    # If you use 'rsa' you can also set RSA key size, 2048, 3072, 4096 (very rare)
 #      - SSHD_PROFILE_SCOPE=host               # Can be 'remote_ip' (each remote IP gets its own profile, simulating per-attacker behavior.), or anything else for 'host' (the same local host always gets the same profile, e.g. binding to 0.0.0.0:22 will always select the same Profile).
-#      - SSHD_SEND_BANNER=false                # Send SSH Login Banner before Password prompt  
-#      - SSHD_LOG_CLEAR_PASSWORD=true          # Log Passwords as clear text or Base64 coded  
+#      - SSHD_SEND_BANNER=false                # Send SSH Login Banner before Password prompt
+#      - SSHD_LOG_CLEAR_PASSWORD=true          # Log Passwords as clear text or Base64 coded
+#      - SSHD_LOGS_FILTER=duser,src,password   # Comma-separated list of allowed fields. 'msg', 'level' and 'time' can't be removed. Following combinations are possible: duser,src,spt,dst,dpt,client_version,server_version,password,keytype,fingerprint,server_key_type,destinationServicename,product,<ALL SSHD_* VARIABLES>
       - TZ=Europe/Berlin                      # You can set Time Zone to see logs with your local time
     volumes:
       # Mount log file if needed

--- a/main.go
+++ b/main.go
@@ -353,6 +353,7 @@ func getEnvWithDefault(key, fallback string) string {
 	return value
 }
 
+// parseAllowedFields parses a comma-separated list of allowed fields
 func parseAllowedFields(env string) map[string]bool {
 	fields := make(map[string]bool)
 	for _, f := range strings.Split(env, ",") {
@@ -369,6 +370,7 @@ type FilteredJSONFormatter struct {
 	Base    *logrus.JSONFormatter
 }
 
+// Format filters the log entry to include only allowed fields
 func (f *FilteredJSONFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	// Avoid null pointer if Base is not set
 	base := f.Base


### PR DESCRIPTION
Logs seems sometime too big, so I add log filtering to reduce amount of information that I do not use any way. For me personally needed only `duser,src,client_version,server_version,password,keytype,fingerprint`

Configurable via `SSHD_LOGS_FILTER` that basically is a comma-separated list of allowed fields: `duser,src,spt,dst,dpt,client_version,server_version,password,keytype,fingerprint,server_key_type,destinationServicename,product`

`msg`, `level` and `time` can't be removed and not listed here.

If variable is not set or set to `SSHD_LOGS_FILTER=""`, everything will be logged as before, however if variable is set to `" "` nothing will be logged and I will show warning on start. Of course if wrong values will be set, they will affect output too.