### PR TITLE
Feat telnet

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+README.md
+Dockerfile
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ LABEL maintainer="Justin Azoff <justin.azoff@gmail.com>" \
 
 ENV USER=nobody
 ENV SSHD_BIND=:2222
+ENV TELNET_BIND=:2323
 
 WORKDIR /app
 
@@ -22,6 +23,6 @@ RUN go install . && \
 
 USER $USER
 
-EXPOSE 2222
+EXPOSE 2222 2323
 
 CMD test -f /var/log/ssh-auth-logger.log || { echo 'Creating log file...' && touch /var/log/ssh-auth-logger.log ; }; /go/bin/ssh-auth-logger 2>&1 | tee -a /var/log/ssh-auth-logger.log

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ services:
     image: justinazoff/ssh-auth-logger:latest
     container_name: ssh-auth-logger
     environment:
+      - TZ=Europe/Berlin                      # You can set Time Zone to see logs with your local time
       # Following are default values
+      # SSHD Part
 #      - SSHD_RATE=320                         # bits per second, emulate very slow connection
 #      - SSHD_BIND=:2222                       # Port and interface sshd to listen
 #      - SSHD_KEY_KEY="Take me to your leader" # It's a secret key that is used to generate a deterministic hash value for a given host IP address
@@ -82,9 +84,10 @@ services:
 #      - SSHD_SEND_BANNER=false                # Send SSH Login Banner before Password prompt
 #      - SSHD_LOG_CLEAR_PASSWORD=true          # Log Passwords as clear text or Base64 coded
 #      - SSHD_LOGS_FILTER=""                   # Comma-separated list of allowed fields. 'msg', 'level' and 'time' can't be removed. Following combinations are possible: "duser,src,spt,dst,dpt,client_version,server_version,password,keytype,fingerprint,server_key_type,destinationServicename,product"
+      # Telnet Part
 #      - TELNET_BIND=:2323                     # Port and interface telnetd to listen
 #      - TELNET_LOG_CLEAR_PASSWORD=true        # Log Passwords as clear text or Base64 coded
-      - TZ=Europe/Berlin                      # You can set Time Zone to see logs with your local time
+#      - TELNET_RATE=20                        # bits per second, emulate very slow connection
     volumes:
       # Mount log file if needed
       - /var/docker/ssh-auth-logger/log:/var/log

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ services:
     container_name: ssh-auth-logger
     environment:
       # Following are default values
-#      - SSHD_RATE=120                         # bits per second, emulate very slow connection
-#      - SSHD_BIND=:22                         # Port and interface to listen
+#      - SSHD_RATE=320                         # bits per second, emulate very slow connection
+#      - SSHD_BIND=:2222                       # Port and interface sshd to listen
 #      - SSHD_KEY_KEY="Take me to your leader" # It's a secret key that is used to generate a deterministic hash value for a given host IP address
 #      - SSHD_MAX_AUTH_TRIES=6                 # The minimum number of authentication attempts allowed
 #      - SSHD_RSA_BITS=3072                    # If you use 'rsa' you can also set RSA key size, 2048, 3072, 4096 (very rare)
@@ -82,12 +82,15 @@ services:
 #      - SSHD_SEND_BANNER=false                # Send SSH Login Banner before Password prompt
 #      - SSHD_LOG_CLEAR_PASSWORD=true          # Log Passwords as clear text or Base64 coded
 #      - SSHD_LOGS_FILTER=""                   # Comma-separated list of allowed fields. 'msg', 'level' and 'time' can't be removed. Following combinations are possible: "duser,src,spt,dst,dpt,client_version,server_version,password,keytype,fingerprint,server_key_type,destinationServicename,product"
+#      - TELNET_BIND=:2323                     # Port and interface telnetd to listen
+#      - TELNET_LOG_CLEAR_PASSWORD=true        # Log Passwords as clear text or Base64 coded
       - TZ=Europe/Berlin                      # You can set Time Zone to see logs with your local time
     volumes:
       # Mount log file if needed
       - /var/docker/ssh-auth-logger/log:/var/log
     ports:
-     - 2222:22 # SSH Auth Logger
+     - 2222:2222 # SSH Auth Logger
+     - 2323:2323 # SSH Auth Logger Telnet
     networks:
       # Use isolated docker network, so that other containers will be not reachable from it
       - isolated_net

--- a/main.go
+++ b/main.go
@@ -7,19 +7,23 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
-	"log"
 	"math/rand"
 	"net"
 	"os"
 	"strconv"
 	"time"
 	"strings"
+	"encoding/base64"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 )
 
 const appName = "ssh-auth-logger"
+
+var telnetBind string
+
+var telnetLogClearPassword bool
 
 var errAuthenticationFailed = errors.New(":)")
 
@@ -61,6 +65,73 @@ type serverProfile struct {
 	ServerVersion string
 	LoginBanner   string
 	HostKeyType   string // "rsa" or "ed25519"
+}
+
+// Telnet handler
+func handleTelnetConnection(conn net.Conn) {
+	defer conn.Close()
+
+	logger.WithFields(connLogParameters(conn)).
+		WithField("destinationServicename", "telnetd").
+		Info("Connection")
+
+	limitedConn := newRateLimitedConn(conn, rate)
+
+	// Fake banner
+	limitedConn.Write([]byte("Ubuntu 24.04 LTS\r\n"))
+	limitedConn.Write([]byte("login: "))
+
+	username, _ := readLine(limitedConn)
+
+	limitedConn.Write([]byte("Password: "))
+	password, _ := readLine(limitedConn)
+
+	var loggedPassword any = password
+	// This will show the password in cleartext if telnetLogClearPassword is true, otherwise it will log the base64 encoded if telnetLogClearPassword is false
+	if telnetLogClearPassword {
+		loggedPassword = string(password)
+	} else {
+		loggedPassword = base64.StdEncoding.EncodeToString([]byte(password))
+	}
+
+	fields := connLogParameters(conn)
+	fields["duser"] = username
+	fields["password"] = loggedPassword
+	fields["protocol"] = "telnet"
+
+	logger.WithFields(fields).
+		WithField("destinationServicename", "telnetd").
+		Info("Telnet login attempt")
+
+	time.Sleep(2 * time.Second)
+	limitedConn.Write([]byte("\r\nLogin incorrect\r\n"))
+}
+
+// Simple Telnet Parser
+func readLine(conn net.Conn) (string, error) {
+	buf := make([]byte, 1)
+	var result []byte
+
+	for {
+		n, err := conn.Read(buf)
+		if err != nil || n == 0 {
+			return "", err
+		}
+
+		// Ignore CR
+		if buf[0] == '\r' {
+			continue
+		}
+
+		// End on LF
+		if buf[0] == '\n' {
+			break
+		}
+
+		result = append(result, buf[0])
+	}
+
+	return strings.TrimSpace(string(result)), nil
 }
 
 // newRateLimitedConn returns a new rateLimitedConn.
@@ -277,6 +348,7 @@ func makeSSHConfig(conn net.Conn) ssh.ServerConfig {
 			time.Sleep(base + jitter)
 
 			var loggedPassword any = password
+			// This will convert bytes to string if logClearPassword is true, otherwise it will log the byte slice (which will be base64 encoded if LogClearPassword is false)
 			if logClearPassword {
 				loggedPassword = string(password)
 			}
@@ -397,9 +469,11 @@ func (f *FilteredJSONFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 func init() {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
 
+	telnetBind = getEnvWithDefault("TELNET_BIND", ":23")
+
 	sshd_bind = getEnvWithDefault("SSHD_BIND", ":22")
 	sshd_key_key = getEnvWithDefault("SSHD_KEY_KEY", "Take me to your leader")
-	rateStr := getEnvWithDefault("SSHD_RATE", "120") // default rate is 120 bytes per second very slow...
+	rateStr := getEnvWithDefault("SSHD_RATE", "320") // default rate is 320 bytes per second very slow...
 	var err error
 	rate, err = strconv.Atoi(rateStr)
 	if err != nil {
@@ -424,20 +498,24 @@ func init() {
 	sendBanner = sendBannerStr == "1" || sendBannerStr == "true" || sendBannerStr == "yes"
 	logClearPasswordStr := getEnvWithDefault("SSHD_LOG_CLEAR_PASSWORD", "true")
 	logClearPassword = logClearPasswordStr == "1" || logClearPasswordStr == "true" || logClearPasswordStr == "yes"
+	telnetLogClearPasswordStr := getEnvWithDefault("TELNET_LOG_CLEAR_PASSWORD", "true")
+	telnetLogClearPassword = telnetLogClearPasswordStr == "1" || telnetLogClearPasswordStr == "true" || telnetLogClearPasswordStr == "yes"
 	// Comma-separated list of allowed fields, "" means all, " " means none
 	logsEnv := getEnvWithDefault("SSHD_LOGS_FILTER", "")
 
 	// Show Configuration on Startup
 	logrus.WithFields(logrus.Fields{
-		"SSHD_BIND":               sshd_bind,
-		"SSHD_KEY_KEY":            sshd_key_key,
-		"SSHD_RATE":               rate,
-		"SSHD_MAX_AUTH_TRIES":     maxAuthTries,
-		"SSHD_RSA_BITS":           rsaBitsStr,
-		"SSHD_PROFILE_SCOPE":      profileScope,
-		"SSHD_SEND_BANNER":        sendBanner,
-		"SSHD_LOG_CLEAR_PASSWORD": logClearPassword,
-		"SSHD_LOGS_FILTER":	       logsEnv,
+		"SSHD_BIND":                 sshd_bind,
+		"SSHD_KEY_KEY":              sshd_key_key,
+		"SSHD_RATE":                 rate,
+		"SSHD_MAX_AUTH_TRIES":       maxAuthTries,
+		"SSHD_RSA_BITS":             rsaBitsStr,
+		"SSHD_PROFILE_SCOPE":        profileScope,
+		"SSHD_SEND_BANNER":          sendBanner,
+		"SSHD_LOG_CLEAR_PASSWORD":   logClearPassword,
+		"SSHD_LOGS_FILTER":	         logsEnv,
+		"TELNET_BIND":               telnetBind,
+		"TELNET_LOG_CLEAR_PASSWORD": telnetLogClearPassword,
 	}).Info("Starting SSH Auth Logger")
 
 	// Configure allowed log fields from environment variable
@@ -461,22 +539,45 @@ func init() {
 }
 
 func main() {
-	socket, err := net.Listen("tcp", sshd_bind)
-	if err != nil {
-		panic(err)
-	}
-	for {
-		conn, err := socket.Accept()
+	// SSH listener
+	go func() {
+		socket, err := net.Listen("tcp", sshd_bind)
 		if err != nil {
-			log.Panic(err)
+			panic(err)
 		}
+		// logrus.Infof("SSH listening on %s", sshd_bind)
+		for {
+			conn, err := socket.Accept()
+			if err != nil {
+				logrus.WithError(err).Warn("SSH listener accept failed")
+				continue
+			}
 
-		logger.WithFields(connLogParameters(conn)).Info("Connection")
+			logger.WithFields(connLogParameters(conn)).Info("SSH connection")
 
-		limitedConn := newRateLimitedConn(conn, rate)
+			limitedConn := newRateLimitedConn(conn, rate)
+			config := makeSSHConfig(conn)
+			go handleConnection(limitedConn, &config)
+		}
+	}()
 
-		config := makeSSHConfig(conn) // NEW CONFIG PER CONNECTION
-		go handleConnection(limitedConn, &config)
-	}
+	// Telnet listener
+	go func() {
+		telnetSocket, err := net.Listen("tcp", telnetBind)
+		if err != nil {
+			panic(err)
+		}
+		// logrus.Infof("Telnet listening on %s", telnetBind)
+		for {
+			conn, err := telnetSocket.Accept()
+			if err != nil {
+				logrus.WithError(err).Warn("Telnet listener accept failed")
+				continue
+			}
+			go handleTelnetConnection(conn)
+		}
+	}()
 
+	// Block forever
+	select {}
 }

--- a/main.go
+++ b/main.go
@@ -79,8 +79,35 @@ func handleTelnetConnection(conn net.Conn) {
 
 	limitedConn := newRateLimitedConn(conn, telnetRate)
 
-	// Fake banner
-	limitedConn.Write([]byte("Ubuntu 24.04 LTS\r\n"))
+
+	// Determine profile key (same logic as SSH)
+	var profileKey string
+	if profileScope == "remote_ip" {
+		host, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+		if err != nil {
+			host = conn.RemoteAddr().String()
+		}
+		profileKey = host
+	} else {
+		profileKey = getHost(conn.LocalAddr().String())
+	}
+
+	profile := getServerProfile(profileKey)
+
+	// Start from SSH login banner
+	banner := profile.LoginBanner
+
+	// Replace protocol-specific words for Telnet realism
+	banner = strings.ReplaceAll(banner, "SSH", "Telnet")
+	banner = strings.ReplaceAll(banner, "ssh", "telnet")
+
+	// Convert LF to CRLF for telnet
+	banner = strings.ReplaceAll(banner, "\n", "\r\n")
+
+	if banner != "" {
+		limitedConn.Write([]byte(banner))
+	}
+
 	limitedConn.Write([]byte("login: "))
 
 	username, _ := readLine(limitedConn)
@@ -291,6 +318,11 @@ var serverProfiles = []serverProfile{
 	{
 		ServerVersion: "SSH-2.0-OpenSSH_8.2p1 Ubuntu-4ubuntu0.5",
 		LoginBanner:   "Ubuntu 20.04.6 LTS\n\nUnauthorized access prohibited.\n",
+		HostKeyType:   "ed25519",
+	},
+	{
+		ServerVersion: "SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.14",
+		LoginBanner:   "Ubuntu 24.04.6 LTS\n\nUnauthorized access prohibited.\n",
 		HostKeyType:   "ed25519",
 	},
 	{

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func handleTelnetConnection(conn net.Conn) {
 
 	logger.WithFields(connLogParameters(conn)).
 		WithField("destinationServicename", "telnetd").
-		Info("Connection")
+		Info("Telnet connection")
 
 	limitedConn := newRateLimitedConn(conn, telnetRate)
 

--- a/main.go
+++ b/main.go
@@ -25,6 +25,8 @@ var telnetBind string
 
 var telnetLogClearPassword bool
 
+var telnetRate int
+
 var errAuthenticationFailed = errors.New(":)")
 
 var commonFields = logrus.Fields{
@@ -75,7 +77,7 @@ func handleTelnetConnection(conn net.Conn) {
 		WithField("destinationServicename", "telnetd").
 		Info("Connection")
 
-	limitedConn := newRateLimitedConn(conn, rate)
+	limitedConn := newRateLimitedConn(conn, telnetRate)
 
 	// Fake banner
 	limitedConn.Write([]byte("Ubuntu 24.04 LTS\r\n"))
@@ -479,6 +481,11 @@ func init() {
 	if err != nil {
 		logrus.Fatal("Invalid SSHD_RATE environment variable")
 	}
+	telnetRateStr := getEnvWithDefault("TELNET_RATE", "20") // Could be slower than SSH
+	telnetRate, err = strconv.Atoi(telnetRateStr)
+	if err != nil || telnetRate <= 0 {
+		logrus.Fatal("Invalid TELNET_RATE environment variable")
+	}
 	maxAuthTriesStr := getEnvWithDefault("SSHD_MAX_AUTH_TRIES", "6") // default amount of tries is 6-10.
 	maxAuthTries, err = strconv.Atoi(maxAuthTriesStr)
 	if err != nil {
@@ -516,6 +523,7 @@ func init() {
 		"SSHD_LOGS_FILTER":	         logsEnv,
 		"TELNET_BIND":               telnetBind,
 		"TELNET_LOG_CLEAR_PASSWORD": telnetLogClearPassword,
+		"TELNET_RATE":               telnetRate,
 	}).Info("Starting SSH Auth Logger")
 
 	// Configure allowed log fields from environment variable

--- a/main.go
+++ b/main.go
@@ -147,6 +147,16 @@ func readLine(conn net.Conn) (string, error) {
 			return "", err
 		}
 
+		b := buf[0]
+
+		// TELNET IAC handling (skip command sequences)
+		if b == 255 { // IAC
+			// read next two bytes (command + option)
+			conn.Read(buf)
+			conn.Read(buf)
+			continue
+		}
+
 		// Ignore CR
 		if buf[0] == '\r' {
 			continue


### PR DESCRIPTION
There is optional Telnet honeypod, that will output the same kind of logs, working on port `2323` and it is fully optional.

Following settings are new:
```yaml
      - TELNET_BIND=:2323                     # Port and interface telnetd to listen
      - TELNET_LOG_CLEAR_PASSWORD=true        # Log Passwords as clear text or Base64 coded
      - TELNET_RATE=20                        # bits per second, emulate very slow connection
```
