### PR TITLE
Enable aes128-cbc and 3des old insecure ciphers support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ LABEL maintainer="Justin Azoff <justin.azoff@gmail.com>" \
 ENV USER=nobody
 ENV SSHD_BIND=:2222
 ENV TELNET_BIND=:2323
+# This is needed to enable aes128-cbc and 3des old insecure ciphers support
+ENV GODEBUG="sshserverinsecurecbc=1"
 
 WORKDIR /app
 


### PR DESCRIPTION
Enable aes128-cbc and 3des old insecure ciphers support

(cherry picked from commit 56b203a9ca9691a2cce0861c4038fb379396afba)

Issue:

Current implementation supports old CBC Ciphers, but I miss that they shall be explicitly enabled. If client force CBC ciphers use, there will be an nil pointer exception raised.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x58c1a1]
goroutine 11361 [running]:
golang.org/x/crypto/ssh.newPacketCipher({{0x810724, 0x1, 0x1}, {0x810725, 0x1, 0x1}, {0x810726, 0x1, 0x1}}, {{0x30d8cafcc290, ...}, ...}, ...)
    /go/pkg/mod/golang.org/x/crypto@v0.1.0/ssh/transport.go:251 +0x1c1
golang.org/x/crypto/ssh.(*transport).prepareKeyChange(0x30d8cb0597a0, 0x30d8cb102400, 0x30d8cafe2400)
    /go/pkg/mod/golang.org/x/crypto@v0.1.0/ssh/transport.go:80 +0x126
golang.org/x/crypto/ssh.(*handshakeTransport).enterKeyExchange(0x30d8cb300000, {0x30d8cb30c280, 0x255, 0x255})
    /go/pkg/mod/golang.org/x/crypto@v0.1.0/ssh/handshake.go:623 +0x49a
golang.org/x/crypto/ssh.(*handshakeTransport).kexLoop(0x30d8cb300000)
    /go/pkg/mod/golang.org/x/crypto@v0.1.0/ssh/handshake.go:301 +0x166
created by golang.org/x/crypto/ssh.newServerTransport in goroutine 11231
    /go/pkg/mod/golang.org/x/crypto@v0.1.0/ssh/handshake.go:143 +0x136
```